### PR TITLE
Correct category slugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/k3ii/qdir"
 homepage = "https://github.com/k3ii/qdir"
 readme = "README.md"
 keywords = ["cli"]
-categories = ["cli"]
+categories = ["command-line-utilities"]
 
 [dependencies]
 clap = { version = "4.5.16", features = ["derive", "cargo"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,12 +39,4 @@ pub fn make_dir(depth: u8, name_length: usize, name: bool, pet: bool, tmp: bool)
     fs::create_dir_all(&path).expect("Failed to create directory");
 
     println!("{}", path.display());
-
-    let name = get_random_name().unwrap_or_else(|| String::from("default_name"));
-    let pet = get_random_pet()
-        .unwrap_or_else(|| "default_pet")
-        .to_string();
-
-    println!("Name: {}", name);
-    println!("Pet: {}", pet);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{command, Arg};
+use clap::{command, Arg, ArgGroup};
 use qdir::make_dir;
 
 fn main() {
@@ -40,6 +40,11 @@ fn main() {
                 .long("tmp")
                 .action(clap::ArgAction::SetTrue)
                 .help("Use the system's temporary directory"),
+        )
+        .group(
+            ArgGroup::new("name_or_pet_length")
+                .args(&["name", "pet", "length"])
+                .required(false),
         )
         .get_matches();
 


### PR DESCRIPTION
- **fix(qdir): flags name, pet, and length cannot be used together**
- **refactor(qdir): remove debugging lines**
- **fix(cargo): set correct category slugs**
